### PR TITLE
docs: add README for OctoAcme Project Management Docs (closes #2)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,44 @@
+# OctoAcme Project Management Docs
+
+Overview
+--------
+This folder centralizes OctoAcme’s project management processes to ensure consistent delivery, faster onboarding, and shared understanding across teams. The documents here describe our lifecycle from project initiation through release and continuous improvement, including roles, templates, and checklists.
+
+At-a-glance: OctoAcme process highlights
+- Customer-first delivery and data-informed decisions
+- Iterative delivery in small, testable increments
+- Clear ownership: Project Manager (PM) and Product Lead for each project
+- Explicit artifacts: One-pager, backlog, Definition of Done, Risk Register, release notes, and retrospectives
+- Regular cadence: standups, weekly syncs, demos, and retrospective cycles
+- Emphasis on quality: tests, CI, security scans, and smoke tests before release
+
+Process documents in this folder
+- [Project Management Overview](docs/octoacme-project-management-overview.md)
+- [Project Initiation Guide](docs/octoacme-project-initiation.md)
+- [Project Planning](docs/octoacme-project-planning.md)
+- [Execution & Tracking](docs/octoacme-execution-and-tracking.md)
+- [Risks & Communication](docs/octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](docs/octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](docs/octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](docs/octoacme-roles-and-personas.md)
+
+How to use these docs
+- Start with the Project Management Overview for the big picture.
+- Use the Project Initiation Guide to create a One-pager and confirm go/no-go.
+- Follow the Project Planning doc to break the work into a prioritized backlog and release plan.
+- Use Execution & Tracking during delivery, linking issues and PRs back to acceptance criteria.
+- Maintain a Risk Register and keep stakeholders updated following the Risks & Communication template.
+- Use the Release & Deployment guide for pre-release checks and post-deploy verification.
+- Run retrospectives and track action items as described in Retrospective & Continuous Improvement.
+
+Contributing or updating a process doc
+1. Open an issue using the ".github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml" template (or comment on an existing issue).
+2. Make changes in a feature branch and open a small PR describing:
+   - Which doc(s) changed
+   - The reason / rationale
+   - Acceptance criteria (if applicable)
+3. Request at least one reviewer and link the PR to the originating issue (e.g., "Closes #2").
+4. After merge, ensure any related Copilot Space or .copilot/ context is updated if relevant.
+
+Contact / Questions
+- For doc ownership, process questions, or to propose changes: open an issue and tag the PM or Product Lead for the project.


### PR DESCRIPTION
Adds docs/README.md to provide an entry point and concise summary of OctoAcme project management processes.\n\nCloses #2